### PR TITLE
Readwok/Mokuro/Wikipedia/Texthooker integration

### DIFF
--- a/src/content/ttu_inject.ts
+++ b/src/content/ttu_inject.ts
@@ -1,6 +1,0 @@
-'use strict';
-(async () => {
-    const browser = (globalThis as any).browser ?? (globalThis as any).chrome;
-    const mod: typeof import('./ttu.js') = await import(browser.runtime.getURL('/content/ttu.js'));
-    await mod.startParsingVisible();
-})();

--- a/src/integrations/anacreon.ts
+++ b/src/integrations/anacreon.ts
@@ -1,0 +1,48 @@
+'use strict';
+(async () => {
+    const browser = (globalThis as any).browser ?? (globalThis as any).chrome;
+    const mod: typeof import('./common.js') = await import(browser.runtime.getURL('/integrations/common.js'));
+    const observeParagraph = (p: HTMLElement, paragraphOnScreenObserver: IntersectionObserver) => {
+        if (p.innerText.trim().length == 0) {
+            // Paragraph is empty
+            return;
+        }
+
+        if (p.classList.contains('jpdb-parse-done'))
+            // Already parsed
+            return;
+
+        paragraphOnScreenObserver.observe(p);
+    }
+
+    const stuffAfter = (observeParagraph: Function, paragraphOnScreenObserver: IntersectionObserver) => {
+        document.querySelectorAll('.textline,.line_box').forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
+
+        const newParagraphObserver = new MutationObserver((mutations, _observer) => {
+            for (const mutation of mutations) {
+                if (mutation.type !== 'childList') continue;
+
+                for (const node of mutation.addedNodes) {
+                    // if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+                    if (node.nodeName === "DIV") {
+                        // (node as HTMLElement).querySelectorAll("span[class=\"\"]").forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
+                        (node as HTMLElement).querySelectorAll("span").forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
+                        // observeParagraph(node as HTMLElement);
+                    }
+                    // else (node as HTMLElement).querySelectorAll('p').forEach(observeParagraph);
+                }
+            }
+        });
+
+        newParagraphObserver.observe(document.body, {
+            subtree: true,
+            childList: true,
+        });
+
+    };
+
+    await mod.startParsingVisible(observeParagraph, stuffAfter);
+
+
+})();

--- a/src/integrations/anacreon.ts
+++ b/src/integrations/anacreon.ts
@@ -23,14 +23,9 @@
                 if (mutation.type !== 'childList') continue;
 
                 for (const node of mutation.addedNodes) {
-                    // if (node.nodeType !== Node.ELEMENT_NODE) continue;
-
                     if (node.nodeName === "DIV") {
-                        // (node as HTMLElement).querySelectorAll("span[class=\"\"]").forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
                         (node as HTMLElement).querySelectorAll("span").forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
-                        // observeParagraph(node as HTMLElement);
                     }
-                    // else (node as HTMLElement).querySelectorAll('p').forEach(observeParagraph);
                 }
             }
         });

--- a/src/integrations/common.ts
+++ b/src/integrations/common.ts
@@ -1,5 +1,5 @@
 import { showError } from '../util.js';
-import { applyParseResult, requestParse, textFragments } from './content.js';
+import { applyParseResult, requestParse, textFragments } from '../content/content.js';
 
 function* iterTextNodes(node: Node): Generator<Text | HTMLElement> {
     if (node.nodeType === Node.TEXT_NODE) {
@@ -19,7 +19,8 @@ function* iterTextNodes(node: Node): Generator<Text | HTMLElement> {
     }
 }
 
-export async function startParsingVisible() {
+// export async function startParsingVisible(observeParagraph: (p: HTMLElement, paragraphOnScreenObserver: IntersectionObserver) => void) {
+export async function startParsingVisible(observeParagraph: Function, stuffAfter: Function) {
     try {
         const visibleParagraphs = new Set<HTMLElement>(); // queue of paragraphs waiting to be parsed
 
@@ -81,38 +82,9 @@ export async function startParsingVisible() {
         //     'beforeend',
         //     `<div style="position:fixed;top:0;right:120px;bottom:0;left:120px;box-shadow:inset 0 0 8px #f00;pointer-events:none;"></div>`,
         // );
+        //
+        stuffAfter(observeParagraph, paragraphOnScreenObserver);
 
-        function observeParagraph(p: HTMLElement) {
-            if (p.innerText.trim().length == 0)
-                // Paragraph is empty
-                return;
-
-            if (p.classList.contains('jpdb-parse-done'))
-                // Already parsed
-                return;
-
-            paragraphOnScreenObserver.observe(p);
-        }
-
-        document.querySelectorAll('p').forEach(observeParagraph);
-
-        const newParagraphObserver = new MutationObserver((mutations, _observer) => {
-            for (const mutation of mutations) {
-                if (mutation.type !== 'childList') continue;
-
-                for (const node of mutation.addedNodes) {
-                    if (node.nodeType !== Node.ELEMENT_NODE) continue;
-
-                    if (node.nodeName === 'p') observeParagraph(node as HTMLElement);
-                    else (node as HTMLElement).querySelectorAll('p').forEach(observeParagraph);
-                }
-            }
-        });
-
-        newParagraphObserver.observe(document.body, {
-            subtree: true,
-            childList: true,
-        });
     } catch (error) {
         showError(error);
     }

--- a/src/integrations/common.ts
+++ b/src/integrations/common.ts
@@ -19,7 +19,6 @@ function* iterTextNodes(node: Node): Generator<Text | HTMLElement> {
     }
 }
 
-// export async function startParsingVisible(observeParagraph: (p: HTMLElement, paragraphOnScreenObserver: IntersectionObserver) => void) {
 export async function startParsingVisible(observeParagraph: Function, stuffAfter: Function) {
     try {
         const visibleParagraphs = new Set<HTMLElement>(); // queue of paragraphs waiting to be parsed

--- a/src/integrations/mokuro.ts
+++ b/src/integrations/mokuro.ts
@@ -1,0 +1,50 @@
+'use strict';
+(async () => {
+    const browser = (globalThis as any).browser ?? (globalThis as any).chrome;
+    const mod: typeof import('./common.js') = await import(browser.runtime.getURL('/integrations/common.js'));
+
+    //TODO merge all <p> in a textbox (otherwise parsing can get cut off or weird)?
+    const observeParagraph = (p: HTMLElement, paragraphOnScreenObserver: IntersectionObserver) => {
+        if (p.classList.contains('jpdb-parse-done'))
+            // Already parsed
+            return;
+
+        paragraphOnScreenObserver.observe(p);
+    };
+
+    const stuffAfter = (observeParagraph: Function, paragraphOnScreenObserver: IntersectionObserver) => {
+        const getCurrentPage = () => {
+            const id = document.getElementById("pageIdxDisplay") as HTMLElement;
+            const page = id.innerText.split("/")[0].split(",");
+            return page;
+        };
+
+        const parseCurrentPage = () => {
+            const startPages = getCurrentPage();
+            startPages.forEach((page) => {
+                const actualPage = parseInt(page) - 1;
+                const div = document.getElementById("page" + actualPage.toString()) as HTMLElement;
+                observeParagraph(div, paragraphOnScreenObserver);
+            });
+        };
+
+        parseCurrentPage();
+
+        const pageChangeObserver = new MutationObserver((mutations, _observer) => {
+            for (const mutation of mutations) {
+                if (mutation.type !== 'childList') continue;
+                for (const node of mutation.addedNodes) {
+                    if (node.nodeName === '#text') {
+                        parseCurrentPage();
+                    }
+                }
+            }
+        });
+
+        pageChangeObserver.observe(document.getElementById("pageIdxDisplay") as HTMLElement, {
+            childList: true,
+        });
+    };
+    await mod.startParsingVisible(observeParagraph, stuffAfter);
+
+})();

--- a/src/integrations/readwok.ts
+++ b/src/integrations/readwok.ts
@@ -1,0 +1,43 @@
+'use strict';
+(async () => {
+    const browser = (globalThis as any).browser ?? (globalThis as any).chrome;
+    const mod: typeof import('./common.js') = await import(browser.runtime.getURL('/integrations/common.js'));
+    const observeParagraph = (p: HTMLElement, paragraphOnScreenObserver: IntersectionObserver) => {
+        if (p.innerText.trim().length == 0) {
+            // Paragraph is empty
+            return;
+        }
+
+        if (p.classList.contains('jpdb-parse-done'))
+            // Already parsed
+            return;
+
+        paragraphOnScreenObserver.observe(p);
+    }
+
+    const stuffAfter = (observeParagraph: Function, paragraphOnScreenObserver: IntersectionObserver) => {
+        document.querySelectorAll('.styles_text__WPY8-').forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
+
+        const newParagraphObserver = new MutationObserver((mutations, _observer) => {
+            for (const mutation of mutations) {
+                if (mutation.type !== 'childList') continue;
+
+                for (const node of mutation.addedNodes) {
+                    if (node.nodeName === "DIV") {
+                        (node as HTMLElement).querySelectorAll(".styles_text__WPY8-").forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
+                    }
+                }
+            }
+        });
+
+        newParagraphObserver.observe(document.body, {
+            subtree: true,
+            childList: true,
+        });
+
+    };
+
+    await mod.startParsingVisible(observeParagraph, stuffAfter);
+
+
+})();

--- a/src/integrations/ttu.ts
+++ b/src/integrations/ttu.ts
@@ -1,0 +1,42 @@
+'use strict';
+(async () => {
+    const browser = (globalThis as any).browser ?? (globalThis as any).chrome;
+    const mod: typeof import('./common.js') = await import(browser.runtime.getURL('/integrations/common.js'));
+    const observeParagraph = (p: HTMLElement, paragraphOnScreenObserver: IntersectionObserver) => {
+        if (p.innerText.trim().length == 0) {
+            // Paragraph is empty
+            return;
+        }
+
+        if (p.classList.contains('jpdb-parse-done'))
+            // Already parsed
+            return;
+
+        paragraphOnScreenObserver.observe(p);
+    }
+
+    const stuffAfter = (observeParagraph: Function, paragraphOnScreenObserver: IntersectionObserver) => {
+        document.querySelectorAll('p').forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
+
+        const newParagraphObserver = new MutationObserver((mutations, _observer) => {
+            for (const mutation of mutations) {
+                if (mutation.type !== 'childList') continue;
+
+                for (const node of mutation.addedNodes) {
+                    if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+                    if (node.nodeName === 'p') observeParagraph(node as HTMLElement);
+                    else (node as HTMLElement).querySelectorAll('p').forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
+                }
+            }
+        });
+
+        newParagraphObserver.observe(document.body, {
+            subtree: true,
+            childList: true,
+        });
+    };
+
+
+    await mod.startParsingVisible(observeParagraph, stuffAfter);
+})();

--- a/src/integrations/wikipedia.ts
+++ b/src/integrations/wikipedia.ts
@@ -1,0 +1,42 @@
+'use strict';
+(async () => {
+    const browser = (globalThis as any).browser ?? (globalThis as any).chrome;
+    const mod: typeof import('./common.js') = await import(browser.runtime.getURL('/integrations/common.js'));
+    const observeParagraph = (p: HTMLElement, paragraphOnScreenObserver: IntersectionObserver) => {
+        if (p.innerText.trim().length == 0) {
+            // Paragraph is empty
+            return;
+        }
+
+        if (p.classList.contains('jpdb-parse-done'))
+            // Already parsed
+            return;
+
+        paragraphOnScreenObserver.observe(p);
+    }
+
+    const stuffAfter = (observeParagraph: Function, paragraphOnScreenObserver: IntersectionObserver) => {
+        document.querySelectorAll('p,li,a,.wikitable,.mw-page-title-main,.mbox-text-span,.thumbcaption,.mw-headline').forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
+
+        const newParagraphObserver = new MutationObserver((mutations, _observer) => {
+            for (const mutation of mutations) {
+                if (mutation.type !== 'childList') continue;
+
+                for (const node of mutation.addedNodes) {
+                    if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+                    if (node.nodeName === 'p') observeParagraph(node as HTMLElement);
+                    else (node as HTMLElement).querySelectorAll('p').forEach((e) => observeParagraph(e, paragraphOnScreenObserver));
+                }
+            }
+        });
+
+        newParagraphObserver.observe(document.body, {
+            subtree: true,
+            childList: true,
+        });
+    };
+
+
+    await mod.startParsingVisible(observeParagraph, stuffAfter);
+})();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,8 +28,14 @@
     "content_scripts": [
         {
             "matches": ["*://reader.ttsu.app/*", "*://ttu-ebook.web.app/*"],
-            "js": ["content/ttu_inject.js"],
+            "js": ["integrations/ttu.js"],
             "css": ["content/word.css"]
+        },
+        {
+            "matches": ["*://app.readwok.com/*"],
+            "js": ["integrations/readwok.js"],
+            "css": ["content/word.css"]
+        },
         }
     ],
     "background": {
@@ -38,7 +44,9 @@
     },
     "web_accessible_resources": [
         "content/contextmenu.js",
-        "content/ttu.js",
+        "integrations/ttu.js",
+        "integrations/common.js",
+        "integrations/readwok.js",
         "content/content.js",
         "content/dialog.js",
         "content/popup.js",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,6 +37,11 @@
             "css": ["content/word.css"]
         },
         {
+            "matches": ["file:///*mokuro*.html"],
+            "js": ["integrations/mokuro.js"],
+            "css": ["content/word.css"]
+        },
+        {
             "matches": ["*://app.readwok.com/*"],
             "js": ["integrations/readwok.js"],
             "css": ["content/word.css"]
@@ -51,6 +56,7 @@
         "content/contextmenu.js",
         "integrations/ttu.js",
         "integrations/anacreon.js",
+        "integrations/mokuro.js",
         "integrations/common.js",
         "integrations/readwok.js",
         "content/content.js",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -46,6 +46,10 @@
             "js": ["integrations/readwok.js"],
             "css": ["content/word.css"]
         },
+        {
+            "matches": ["*://ja.wikipedia.org/*"],
+            "js": ["integrations/wikipedia.js"],
+            "css": ["content/word.css"]
         }
     ],
     "background": {
@@ -59,6 +63,7 @@
         "integrations/mokuro.js",
         "integrations/common.js",
         "integrations/readwok.js",
+        "integrations/wikipedia.js",
         "content/content.js",
         "content/dialog.js",
         "content/popup.js",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,6 +32,11 @@
             "css": ["content/word.css"]
         },
         {
+            "matches": ["*://anacreondjt.gitlab.io/texthooker.html", "*://learnjapanese.moe/texthooker.html"],
+            "js": ["integrations/anacreon.js"],
+            "css": ["content/word.css"]
+        },
+        {
             "matches": ["*://app.readwok.com/*"],
             "js": ["integrations/readwok.js"],
             "css": ["content/word.css"]
@@ -45,6 +50,7 @@
     "web_accessible_resources": [
         "content/contextmenu.js",
         "integrations/ttu.js",
+        "integrations/anacreon.js",
         "integrations/common.js",
         "integrations/readwok.js",
         "content/content.js",


### PR DESCRIPTION
ttu: mostly unchanged save for refactoring
mokuro: parses page per page (or double page per double page), not much is done aside from that since the new popup system works fine with it now
readwok: nothing in particular, parses with every new thing that comes in, and does the same thing as ttu to not parse out of view paragraphs
texthooker: same as readwok
wikipedia: parses text in view (many things are still unparsed because of the amount of html elements, but not a hard fix), popup text gets parsed but going for the reader's popup can close wikipedia's popup depending on position, but that's basically a wikipedia problem (and the text in the popup is just the article's first few lines so people who really need it can just go to that other page)

pain points/unsure/more work later stuff:
- mokuro files need mokuro in the file name because I didn't look up much on how better it could be handled
- likewise, some people use texthooker pages locally, we could make a rule for filename if there's nothing better
- I considered maybe a button in the settings thing (next to settings) like "this is a mokuro manga", "this is texthooker page" otherwise, but again, maybe I'm missing something better 
- not sure all the web_accessible stuff in the manifest.json was needed
- "stuffAfter" name is bad but honestly don't know what else to call it, brain is mush
- some more refactoring can be done as I noticed a lot of similarities after implementing readwok/wikipedia that I hadn't before doing the refactor
- mokuro has a \<p\> per line even within a textbox, so words/expressions that crosses over doesn't get parsed properly, kind of not a jpdbreader problem I think, and thankfully most manga is typed properly that it might be a rare occurence to be an issue, I might fix this with userscript or weird jank later

tested on firefox/chrome