### PR TITLE
Add support for touchscreen devices.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,8 @@ export type Config = {
 
     showPopupOnHover: boolean;
     touchscreenSupport: boolean;
+    disableFadeAnimation: boolean;
+
     showPopupKey: Keybind;
     addKey: Keybind;
     dialogKey: Keybind;
@@ -52,6 +54,8 @@ export const defaultConfig: Config = {
 
     showPopupOnHover: false,
     touchscreenSupport: false,
+    disableFadeAnimation: false,
+
     showPopupKey: { key: 'Shift', code: 'ShiftLeft', modifiers: [] },
     addKey: null,
     dialogKey: null,

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,8 @@ export type Config = {
     customWordCSS: string;
     customPopupCSS: string;
 
-    showPopupHover: boolean;
+    showPopupOnHover: boolean;
+    touchscreenSupport: boolean;
     showPopupKey: Keybind;
     addKey: Keybind;
     dialogKey: Keybind;
@@ -49,7 +50,8 @@ export const defaultConfig: Config = {
     customWordCSS: '',
     customPopupCSS: '',
 
-    showPopupHover: false,
+    showPopupOnHover: false,
+    touchscreenSupport: false,
     showPopupKey: { key: 'Shift', code: 'ShiftLeft', modifiers: [] },
     addKey: null,
     dialogKey: null,

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export type Config = {
     customWordCSS: string;
     customPopupCSS: string;
 
+    showPopupHover: boolean;
     showPopupKey: Keybind;
     addKey: Keybind;
     dialogKey: Keybind;
@@ -48,6 +49,7 @@ export const defaultConfig: Config = {
     customWordCSS: '',
     customPopupCSS: '',
 
+    showPopupHover: false,
     showPopupKey: { key: 'Shift', code: 'ShiftLeft', modifiers: [] },
     addKey: null,
     dialogKey: null,

--- a/src/content/content.tsx
+++ b/src/content/content.tsx
@@ -17,7 +17,7 @@ function matchesHotkey(
 
 window.addEventListener('keydown', async event => {
     try {
-        if (matchesHotkey(event, config.showPopupKey)) {
+        if (matchesHotkey(event, config.showPopupKey) && !config.showPopupHover) {
             event.preventDefault();
             popupKeyHeld = true;
 
@@ -106,7 +106,7 @@ document.addEventListener('mousedown', () => Popup.get().fadeOut());
 export function onWordHoverStart({ target, x, y }: MouseEvent) {
     if (target === null) return;
     currentHover = [target as JpdbWord, x, y];
-    if (popupKeyHeld) {
+    if (popupKeyHeld || config.showPopupHover) {
         Popup.get().showForWord(target as JpdbWord, x, y);
     }
 }

--- a/src/content/content.tsx
+++ b/src/content/content.tsx
@@ -101,10 +101,11 @@ window.addEventListener('keyup', event => {
     }
 });
 
-document.addEventListener('mousedown', () => {
+document.addEventListener('mousedown', e => {
     if (config.touchscreenSupport) {
-        //  to prevent issues with simultaneous showing and hiding
-        if (currentHover == null) {
+        // to prevent issues with simultaneous showing and hiding
+        // and to allow clicking on the popup without making it disappear.
+        if (currentHover == null && !Popup.get().containsMouse(e)) {
             Popup.get().fadeOut();
         }
     } else {

--- a/src/content/content.tsx
+++ b/src/content/content.tsx
@@ -102,7 +102,14 @@ window.addEventListener('keyup', event => {
 });
 
 document.addEventListener('mousedown', () => {
-    if (!config.touchscreenSupport) Popup.get().fadeOut();
+    if (config.touchscreenSupport) {
+        //  to prevent issues with simultaneous showing and hiding
+        if (currentHover == null) {
+            Popup.get().fadeOut();
+        }
+    } else {
+        Popup.get().fadeOut();
+    }
 });
 
 export function onWordHoverStart({ target, x, y }: MouseEvent) {
@@ -115,5 +122,4 @@ export function onWordHoverStart({ target, x, y }: MouseEvent) {
 
 export function onWordHoverStop() {
     currentHover = null;
-    if (config.touchscreenSupport) Popup.get().fadeOut();
 }

--- a/src/content/content.tsx
+++ b/src/content/content.tsx
@@ -17,7 +17,7 @@ function matchesHotkey(
 
 window.addEventListener('keydown', async event => {
     try {
-        if (matchesHotkey(event, config.showPopupKey) && !config.showPopupHover) {
+        if (matchesHotkey(event, config.showPopupKey) && !config.showPopupOnHover) {
             event.preventDefault();
             popupKeyHeld = true;
 
@@ -101,16 +101,19 @@ window.addEventListener('keyup', event => {
     }
 });
 
-document.addEventListener('mousedown', () => Popup.get().fadeOut());
+document.addEventListener('mousedown', () => {
+    if (!config.touchscreenSupport) Popup.get().fadeOut();
+});
 
 export function onWordHoverStart({ target, x, y }: MouseEvent) {
     if (target === null) return;
     currentHover = [target as JpdbWord, x, y];
-    if (popupKeyHeld || config.showPopupHover) {
+    if (popupKeyHeld || config.showPopupOnHover) {
         Popup.get().showForWord(target as JpdbWord, x, y);
     }
 }
 
 export function onWordHoverStop() {
     currentHover = null;
+    if (config.touchscreenSupport) Popup.get().fadeOut();
 }

--- a/src/content/popup.tsx
+++ b/src/content/popup.tsx
@@ -113,12 +113,9 @@ export class Popup {
 
     static #popup: Popup;
 
-    cooldown: boolean;
-
     static get(): Popup {
         if (!this.#popup) {
             this.#popup = new this();
-            this.#popup.cooldown = false;
             document.body.append(this.#popup.#element);
         }
 
@@ -192,26 +189,15 @@ export class Popup {
     }
 
     fadeIn() {
-        this.cooldown = true;
         this.#outerStyle.transition = 'opacity 60ms ease-in, visibility 60ms';
         this.#outerStyle.opacity = '1';
         this.#outerStyle.visibility = 'visible';
-
-        setTimeout(() => {
-            this.cooldown = false;
-        }, 200);
     }
 
     fadeOut() {
-        setTimeout(() => {
-            if (!this.cooldown) {
-                this.#outerStyle.transition = 'opacity 200ms ease-in, visibility 200ms';
-                this.#outerStyle.opacity = '0';
-                this.#outerStyle.visibility = 'hidden';
-            } else {
-                this.cooldown = false;
-            }
-        }, 200);
+        this.#outerStyle.transition = 'opacity 200ms ease-in, visibility 200ms';
+        this.#outerStyle.opacity = '0';
+        this.#outerStyle.visibility = 'hidden';
     }
 
     disablePointer() {

--- a/src/content/popup.tsx
+++ b/src/content/popup.tsx
@@ -196,6 +196,10 @@ export class Popup {
         this.#outerStyle.transition = 'opacity 60ms ease-in, visibility 60ms';
         this.#outerStyle.opacity = '1';
         this.#outerStyle.visibility = 'visible';
+
+        setTimeout(() => {
+            this.cooldown = false;
+        }, 200);
     }
 
     fadeOut() {

--- a/src/content/popup.tsx
+++ b/src/content/popup.tsx
@@ -189,13 +189,19 @@ export class Popup {
     }
 
     fadeIn() {
-        this.#outerStyle.transition = 'opacity 60ms ease-in, visibility 60ms';
+        // Necessary because in settings page, config is undefined
+        if (config) {
+            if (!config.disableFadeAnimation) this.#outerStyle.transition = 'opacity 60ms ease-in, visibility 60ms';
+        }
         this.#outerStyle.opacity = '1';
         this.#outerStyle.visibility = 'visible';
     }
 
     fadeOut() {
-        this.#outerStyle.transition = 'opacity 200ms ease-in, visibility 200ms';
+        // Necessary because in settings page, config is undefined
+        if (config) {
+            if (!config.disableFadeAnimation) this.#outerStyle.transition = 'opacity 200ms ease-in, visibility 200ms';
+        }
         this.#outerStyle.opacity = '0';
         this.#outerStyle.visibility = 'hidden';
     }

--- a/src/content/popup.tsx
+++ b/src/content/popup.tsx
@@ -299,6 +299,16 @@ export class Popup {
         this.render();
     }
 
+    containsMouse(event: MouseEvent): boolean {
+        const targetElement = event.target as HTMLElement;
+
+        if (targetElement) {
+            return this.#element.contains(targetElement);
+        }
+
+        return false;
+    }
+
     showForWord(word: JpdbWord, mouseX = 0, mouseY = 0) {
         const data = (word as JpdbWord).jpdbData;
         assertNonNull(data);

--- a/src/content/popup.tsx
+++ b/src/content/popup.tsx
@@ -323,15 +323,15 @@ export class Popup {
 
         if (writingMode.startsWith('horizontal')) {
             popupTop = topSpace < bottomSpace ? wordBottom : wordTop - popupHeight;
-            popupLeft = rightSpace > leftSpace ? wordLeft : wordRight - popupWidth;
+            popupLeft = rightSpace > leftSpace ? wordLeft : Math.max(wordLeft - popupWidth, 0);
+            popupLeft = Math.min(popupLeft, window.innerWidth - popupWidth);
         } else {
             popupTop = topSpace < bottomSpace ? wordTop : wordBottom - popupHeight;
-            popupLeft = leftSpace < rightSpace ? wordRight : wordLeft - popupWidth;
+            popupLeft = leftSpace < rightSpace ? wordRight : Math.max(wordRight - popupWidth, 0);
+            popupLeft = Math.min(popupLeft, window.innerWidth - popupWidth);
         }
 
         this.#outerStyle.transform = `translate(${popupLeft}px,${popupTop}px)`;
-
-        console.log(`(Width: ${window.innerWidth}, Height: ${window.innerHeight}) / (X: ${popupLeft}, Y: ${popupTop})`);
 
         this.fadeIn();
     }

--- a/src/content/popup.tsx
+++ b/src/content/popup.tsx
@@ -113,9 +113,12 @@ export class Popup {
 
     static #popup: Popup;
 
+    cooldown: boolean;
+
     static get(): Popup {
         if (!this.#popup) {
             this.#popup = new this();
+            this.#popup.cooldown = false;
             document.body.append(this.#popup.#element);
         }
 
@@ -189,15 +192,22 @@ export class Popup {
     }
 
     fadeIn() {
+        this.cooldown = true;
         this.#outerStyle.transition = 'opacity 60ms ease-in, visibility 60ms';
         this.#outerStyle.opacity = '1';
         this.#outerStyle.visibility = 'visible';
     }
 
     fadeOut() {
-        this.#outerStyle.transition = 'opacity 200ms ease-in, visibility 200ms';
-        this.#outerStyle.opacity = '0';
-        this.#outerStyle.visibility = 'hidden';
+        setTimeout(() => {
+            if (!this.cooldown) {
+                this.#outerStyle.transition = 'opacity 200ms ease-in, visibility 200ms';
+                this.#outerStyle.opacity = '0';
+                this.#outerStyle.visibility = 'hidden';
+            } else {
+                this.cooldown = false;
+            }
+        }, 200);
     }
 
     disablePointer() {
@@ -330,6 +340,8 @@ export class Popup {
         }
 
         this.#outerStyle.transform = `translate(${popupLeft}px,${popupTop}px)`;
+
+        console.log(`(Width: ${window.innerWidth}, Height: ${window.innerHeight}) / (X: ${popupLeft}, Y: ${popupTop})`);
 
         this.fadeIn();
     }

--- a/src/settings_page/settings.html
+++ b/src/settings_page/settings.html
@@ -127,6 +127,7 @@
                 <a href="#general" class="active">General</a>
                 <a href="#mining">Mining</a>
                 <a href="#keybinds">Keybinds</a>
+                <a href="#accessibility">Accessibility</a>
                 <a href="#appearance">Appearance</a>
                 <a href="#import-export">Import/Export</a>
 
@@ -168,7 +169,6 @@
                         have the popup for another word open.
                         <!-- Clearing "Show popup" engages hover mode. -->
                     </div>
-                    <setting-boolean class="setting" name="showPopupHover">No popup key</setting-boolean>
                     <setting-keybind class="setting" name="showPopupKey">Show popup</setting-keybind>
                     <setting-keybind class="setting" name="addKey">Add word to mining deck</setting-keybind>
                     <setting-keybind class="setting" name="dialogKey">Show advanced mining dialog</setting-keybind>
@@ -179,6 +179,11 @@
                     <setting-keybind class="setting" name="hardKey">Review word as hard</setting-keybind>
                     <setting-keybind class="setting" name="goodKey">Review word as good</setting-keybind>
                     <setting-keybind class="setting" name="easyKey">Review word as easy</setting-keybind>
+                </section>
+                <section id="accessibility">
+                    <h1>Accessibility</h1>
+                    <setting-boolean class="setting" name="showPopupOnHover">Show the popup on hover</setting-boolean>
+                    <setting-boolean class="setting" name="touchscreenSupport">Touchscreen support</setting-boolean>
                 </section>
                 <section id="appearance">
                     <h1>Appearance</h1>

--- a/src/settings_page/settings.html
+++ b/src/settings_page/settings.html
@@ -184,6 +184,7 @@
                     <h1>Accessibility</h1>
                     <setting-boolean class="setting" name="showPopupOnHover">Show the popup on hover</setting-boolean>
                     <setting-boolean class="setting" name="touchscreenSupport">Touchscreen support</setting-boolean>
+                    <setting-boolean class="setting" name="disableFadeAnimation">Disable fade animation</setting-boolean>
                 </section>
                 <section id="appearance">
                     <h1>Appearance</h1>

--- a/src/settings_page/settings.html
+++ b/src/settings_page/settings.html
@@ -168,6 +168,7 @@
                         have the popup for another word open.
                         <!-- Clearing "Show popup" engages hover mode. -->
                     </div>
+                    <setting-boolean class="setting" name="showPopupHover">No popup key</setting-boolean>
                     <setting-keybind class="setting" name="showPopupKey">Show popup</setting-keybind>
                     <setting-keybind class="setting" name="addKey">Add word to mining deck</setting-keybind>
                     <setting-keybind class="setting" name="dialogKey">Show advanced mining dialog</setting-keybind>

--- a/src/settings_page/settings.html
+++ b/src/settings_page/settings.html
@@ -184,7 +184,9 @@
                     <h1>Accessibility</h1>
                     <setting-boolean class="setting" name="showPopupOnHover">Show the popup on hover</setting-boolean>
                     <setting-boolean class="setting" name="touchscreenSupport">Touchscreen support</setting-boolean>
-                    <setting-boolean class="setting" name="disableFadeAnimation">Disable fade animation</setting-boolean>
+                    <setting-boolean class="setting" name="disableFadeAnimation"
+                        >Disable fade animation</setting-boolean
+                    >
                 </section>
                 <section id="appearance">
                     <h1>Appearance</h1>


### PR DESCRIPTION
This commit adds support for touchscreen devices by ignoring the "Show Popup" keybind if "Show popup on hover" is enabled in the settings.

The "mousedown" listener event had issues on touchscreen devices because tapping or hovering over a word would also trigger a click event. To address this, a "Touchscreen Support" option has been added to the settings, which changes the behavior to only hide the popup on the `"onmouseleave"` event.

Currently, on small screens, the popup sometimes does not fully appear on the screen.